### PR TITLE
Added Aenea Support

### DIFF
--- a/castervoice/apps/adobe_acrobat.py
+++ b/castervoice/apps/adobe_acrobat.py
@@ -1,6 +1,5 @@
-from dragonfly import Dictation, Key, Repeat, Mouse, Pause, MappingRule
-
-from castervoice.lib.actions import Text
+from dragonfly import Dictation, Repeat, Pause, MappingRule
+from castervoice.lib.actions import Text, Key, Mouse
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/atom.py
+++ b/castervoice/apps/atom.py
@@ -5,10 +5,12 @@ Official Site "https://atom.io/"
 """
 
 # How long to wait for the Atom palette to load before hitting the enter key
-from dragonfly import Key, Pause, Function, Repeat, AppContext, Dictation, Choice, MappingRule
+from dragonfly import Pause, Function, Repeat, Dictation, Choice, MappingRule
+
+from castervoice.lib.actions import Text, Key
+from castervoice.lib.context import AppContext
 
 from castervoice.lib import settings, navigation
-from castervoice.lib.actions import Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/dragon.py
+++ b/castervoice/apps/dragon.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Function, Playback, Mimic, WaitWindow, Repeat, Pause
+from dragonfly import Function, Playback, Mimic, WaitWindow, Repeat, Pause
+from castervoice.lib.actions import Key
+from castervoice.lib.context import AppContext
 
 from castervoice.apps.dragon_support import cap_dictation, fix_dragon_double, extras_for_whole_file, \
     defaults_for_whole_file

--- a/castervoice/apps/dragon2.py
+++ b/castervoice/apps/dragon2.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Mimic
+from dragonfly import Mimic
+from castervoice.lib.actions import Key
+
 
 from castervoice.apps.dragon_support import extras_for_whole_file, defaults_for_whole_file
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails

--- a/castervoice/apps/dragon_support.py
+++ b/castervoice/apps/dragon_support.py
@@ -1,4 +1,4 @@
-from dragonfly import Key, Dictation, Choice
+from dragonfly import Dictation, Choice
 
 from castervoice.lib import utilities
 from castervoice.lib.actions import Text

--- a/castervoice/apps/eclipse.py
+++ b/castervoice/apps/eclipse.py
@@ -1,12 +1,15 @@
-from dragonfly import Key, Repeat, Dictation, Function, Choice, Paste, Pause
+from dragonfly import Repeat, Dictation, Function, Choice, Paste, Pause
 
 from castervoice.apps.eclipse_support import ec_con
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST, Boolean
 from castervoice.lib.merge.mergerule import MergeRule
 from castervoice.lib.merge.state.short import R
+
+from castervoice.lib.actions import Key, Text, Mouse
+from castervoice.lib.context import AppContext
 
 
 class EclipseCCR(MergeRule):

--- a/castervoice/apps/eclipse2.py
+++ b/castervoice/apps/eclipse2.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Repeat, Dictation, Function, Choice, Paste, Pause, MappingRule
+from dragonfly import Repeat, Dictation, Function, Choice, Paste, Pause, MappingRule
+
+from castervoice.lib.actions import Key
 
 from castervoice.apps.eclipse_support import ec_con
 from castervoice.lib import alphanumeric

--- a/castervoice/apps/eclipse_support.py
+++ b/castervoice/apps/eclipse_support.py
@@ -1,6 +1,6 @@
 import re
 
-from dragonfly import Key
+from castervoice.lib.actions import Key
 
 from castervoice.lib import utilities, context
 from castervoice.lib.actions import Text

--- a/castervoice/apps/emacs.py
+++ b/castervoice/apps/emacs.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Dictation, MappingRule
+from dragonfly import Dictation, MappingRule
+
+from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST

--- a/castervoice/apps/excel.py
+++ b/castervoice/apps/excel.py
@@ -9,10 +9,11 @@ import itertools
 
 # this function takes a dictionary and returns a dictionary whose keys are sequences of keys of the original dictionary
 # and whose values our the corresponding sequences of values of the original dictionary
-from dragonfly import Key, Repeat, Dictation, Choice, MappingRule
+from dragonfly import Repeat, Dictation, Choice, MappingRule
+
+from castervoice.lib.actions import Key, Text
 
 from castervoice.lib import alphanumeric
-from castervoice.lib.actions import Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/explorer.py
+++ b/castervoice/apps/explorer.py
@@ -1,6 +1,7 @@
-from dragonfly import Key, Dictation, MappingRule
+from dragonfly import Dictation, MappingRule
 
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key, Text
+
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/file_dialogue.py
+++ b/castervoice/apps/file_dialogue.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule
+
+from castervoice.lib.actions import Key
 
 from castervoice.lib.actions import Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails

--- a/castervoice/apps/flashdevelop.py
+++ b/castervoice/apps/flashdevelop.py
@@ -1,6 +1,7 @@
-from dragonfly import Key, Repeat, Dictation, MappingRule, Pause
+from dragonfly import Repeat, Dictation, MappingRule, Pause
 
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key, Text
+
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/fman.py
+++ b/castervoice/apps/fman.py
@@ -1,6 +1,7 @@
-from dragonfly import Key, Pause, Choice, MappingRule
+from dragonfly import Pause, Choice, MappingRule
 
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key, Text
+
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/foxitreader.py
+++ b/castervoice/apps/foxitreader.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule
+
+from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST

--- a/castervoice/apps/gitbash.py
+++ b/castervoice/apps/gitbash.py
@@ -1,6 +1,7 @@
-from dragonfly import Key, Mimic, Function, MappingRule
+from dragonfly import Mimic, Function, MappingRule
 
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key, Text
+
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/githubdesktop.py
+++ b/castervoice/apps/githubdesktop.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Repeat, MappingRule
+from dragonfly import Repeat, MappingRule
+
+from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST

--- a/castervoice/apps/gitter.py
+++ b/castervoice/apps/gitter.py
@@ -5,7 +5,8 @@ Official Site "https://gitter.im/"
 """
 from dragonfly import Key, Pause, Choice, MappingRule
 
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key, Text
+
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
 from castervoice.lib.temporary import Store, Retrieve

--- a/castervoice/apps/griddouglas.py
+++ b/castervoice/apps/griddouglas.py
@@ -1,7 +1,7 @@
 import time
 
-from dragonfly import Mouse, Function, Choice, MappingRule
-
+from dragonfly import Function, Choice, MappingRule
+from castervoice.lib.actions import Mouse
 from castervoice.lib import settings, control
 from castervoice.asynch.mouse import grids
 import win32api, win32con

--- a/castervoice/apps/gridrainbow.py
+++ b/castervoice/apps/gridrainbow.py
@@ -1,6 +1,8 @@
 import time
 
-from dragonfly import Mouse, Function, Choice, MappingRule
+from dragonfly import Function, Choice, MappingRule
+
+from castervoice.lib.actions import Mouse
 
 from castervoice.asynch.mouse import grids
 import win32api, win32con

--- a/castervoice/apps/kdiff3.py
+++ b/castervoice/apps/kdiff3.py
@@ -1,5 +1,5 @@
-from dragonfly import Key, Dictation, MappingRule
-
+from dragonfly import Dictation, MappingRule
+from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/lyx.py
+++ b/castervoice/apps/lyx.py
@@ -1,5 +1,5 @@
-from dragonfly import Key, Repeat, Choice, MappingRule
-
+from dragonfly import Repeat, Choice, MappingRule
+from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/msvc.py
+++ b/castervoice/apps/msvc.py
@@ -1,5 +1,5 @@
-from dragonfly import Key, Repeat, Dictation, MappingRule
-
+from dragonfly import Repeat, Dictation, MappingRule
+from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/notepadplusplus.py
+++ b/castervoice/apps/notepadplusplus.py
@@ -1,4 +1,6 @@
-from dragonfly import Mouse, Key, Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule
+
+from castervoice.lib.actions import Key, Text, Mouse
 
 from castervoice.lib.actions import Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails

--- a/castervoice/apps/outlook.py
+++ b/castervoice/apps/outlook.py
@@ -1,6 +1,6 @@
-from dragonfly import Key, Function, Repeat, Dictation, Choice, AppContext
+from dragonfly import Function, Repeat, Dictation, Choice, AppContext
 
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key, Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule

--- a/castervoice/apps/rstudio.py
+++ b/castervoice/apps/rstudio.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Pause, Function, Choice, MappingRule
+from dragonfly import Pause, Function, Choice, MappingRule
+
+from castervoice.lib.actions import Key, Text, Mouse
 
 from castervoice.lib import navigation
 from castervoice.lib.actions import Text

--- a/castervoice/apps/sqldeveloper.py
+++ b/castervoice/apps/sqldeveloper.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Dictation, MappingRule
+from dragonfly import Dictation, MappingRule
+
+from castervoice.lib.actions import Key
 
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST

--- a/castervoice/apps/ssms.py
+++ b/castervoice/apps/ssms.py
@@ -1,5 +1,5 @@
-from dragonfly import Key, Repeat, Dictation, MappingRule
-
+from dragonfly import Repeat, Dictation, MappingRule
+from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/sublime.py
+++ b/castervoice/apps/sublime.py
@@ -1,7 +1,7 @@
-from dragonfly import Key, Function, Dictation, Choice
+from dragonfly import Function, Dictation, Choice
 
 from castervoice.lib import navigation
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key, Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.mergerule import MergeRule

--- a/castervoice/apps/totalcmd.py
+++ b/castervoice/apps/totalcmd.py
@@ -1,5 +1,5 @@
-from dragonfly import Key, MappingRule
-
+from dragonfly import MappingRule
+from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
 

--- a/castervoice/apps/totalcmd2.py
+++ b/castervoice/apps/totalcmd2.py
@@ -1,5 +1,6 @@
-from dragonfly import Key, MappingRule
+from dragonfly import MappingRule
 
+from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.state.short import R
 

--- a/castervoice/apps/typora.py
+++ b/castervoice/apps/typora.py
@@ -3,8 +3,9 @@ __author__ = 'LexiconCode'
 Command-module for Typora
 Official Site "https://typora.io/"
 """
-from dragonfly import Key, Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule
 
+from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/visualstudio.py
+++ b/castervoice/apps/visualstudio.py
@@ -1,7 +1,7 @@
-from dragonfly import Key, Repeat, Dictation, MappingRule
+from dragonfly import Repeat, Dictation, MappingRule
 
 
-from castervoice.lib.actions import Text
+from castervoice.lib.actions import Key, Text
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R

--- a/castervoice/apps/vscode.py
+++ b/castervoice/apps/vscode.py
@@ -1,5 +1,7 @@
 # thanks to Casper for contributing commands to this.
-from dragonfly import Key, Repeat, Dictation, Choice
+from dragonfly import Repeat, Dictation, Choice
+
+from castervoice.lib.actions import Key
 
 from castervoice.lib.const import CCRType
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails

--- a/castervoice/apps/vscode2.py
+++ b/castervoice/apps/vscode2.py
@@ -1,4 +1,6 @@
-from dragonfly import Key, Function, Repeat, Choice, Dictation, MappingRule
+from dragonfly import Function, Repeat, Choice, Dictation, MappingRule
+
+from castervoice.lib.actions import Key
 
 from castervoice.lib import navigation
 from castervoice.lib.actions import Text

--- a/castervoice/apps/winword.py
+++ b/castervoice/apps/winword.py
@@ -1,5 +1,5 @@
-from dragonfly import Key, Dictation, MappingRule
-
+from dragonfly import Dictation, MappingRule
+from castervoice.lib.actions import Key
 from castervoice.lib.ctrl.mgr.rule_details import RuleDetails
 from castervoice.lib.merge.additions import IntegerRefST
 from castervoice.lib.merge.state.short import R


### PR DESCRIPTION
This is done simply by changing imports from 
`from dragonfly import Text, Key, Mouse`
to 
`from castervoice.lib.actions import Text, Key, Mouse`

See [actions.py](https://github.com/LexiconCode/Caster/blob/ccrmerger2/castervoice/lib/actions.py)
 There's more to be done across the CodeBase